### PR TITLE
docs: Correction of text for clarity Update other-essential-protocols.md

### DIFF
--- a/our-product-suite/other-essential-protocols.md
+++ b/our-product-suite/other-essential-protocols.md
@@ -24,7 +24,7 @@ The [main problem](https://foresightnews.pro/article/detail/48043) with the BRC-
 ### **Solution-1 with Fiamma (ZKIndexer):**
 
 1. Secured by Bitcoin - By integrating the Fiamma, the value of the BRC-20 token is secured by Bitcoin via Babylon and BitVM2;
-2. Separated ledger - different projects may operate different indexers, causing token loss;
+2. Separated ledger - different projects may operate different indexers, causing the token value loss;
 3. Secured by Bitcoin - By integrating the Fiamma, the value of the BRC-20 token is secured by Bitcoin via Babylon and BitVM2;
 4. Unified ledger - the same ledger, the same value;
 


### PR DESCRIPTION
In the **Solution-1 with Fiamma (ZKIndexer)** section, point 2 contained a minor wording issue. The phrase **"causing token loss;"** was unclear, as it referred to the token rather than the token value.

The text has been updated to **"causing the token value loss;"** for clarity and consistency with the rest of the content. 